### PR TITLE
Added x:Uid to key group

### DIFF
--- a/TestMarkupExtensionHandling.xaml
+++ b/TestMarkupExtensionHandling.xaml
@@ -29,7 +29,8 @@
         <TextBlock Style="{DynamicResource {x:Static SystemColors.ControlTextBrushKey},
                                        ResourceKey={x:Static SystemColors.ControlTextBrushKey}}"
                Text="Foreground"
-               x:Uid="Setter_75" />
+               x:Uid="KeyForResources"
+               x:Name="TextBlockWithResources" />
 
         <!-- Quoted Value -->
         <TextBlock Style="SomeStyle"

--- a/TestMarkupExtensionHandling_output_expected.xaml
+++ b/TestMarkupExtensionHandling_output_expected.xaml
@@ -24,21 +24,22 @@
                               StringFormat={}{0:##\,#0.00;(##\,#0.00); }}" />
 
 
-    <TextBlock Style="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-               Text="Foreground"
-               x:Uid="Setter_75" />
+    <TextBlock x:Uid="Setter_75"
+               Style="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+               Text="Foreground" />
 
-    <TextBlock Style="{DynamicResource {x:Static SystemColors.ControlTextBrushKey},
+    <TextBlock x:Uid="KeyForResources"
+               x:Name="TextBlockWithResources"
+               Style="{DynamicResource {x:Static SystemColors.ControlTextBrushKey},
                                        ResourceKey={x:Static SystemColors.ControlTextBrushKey}}"
-               Text="Foreground"
-               x:Uid="Setter_75" />
+               Text="Foreground" />
 
     <!--  Quoted Value  -->
-    <TextBlock Style="SomeStyle"
+    <TextBlock x:Uid="Setter_87"
+               Style="SomeStyle"
                Text="{Binding Path=U1State,
                               Converter={StaticResource Enum2BooleanConverter},
-                              ConverterParameter='Adjustment,ToManualFromAdjustment,ToSemiAutoFromAdjustment,ToAutoFromAdjustment'}"
-               x:Uid="Setter_87" />
+                              ConverterParameter='Adjustment,ToManualFromAdjustment,ToSemiAutoFromAdjustment,ToAutoFromAdjustment'}" />
 
     <TextBlock Text="{Binding Path=Text, ElementName=m_source, StringFormat='{}{0} , {0}'}" />
 

--- a/XamlStyler.Service/Options/IStylerOptions.cs
+++ b/XamlStyler.Service/Options/IStylerOptions.cs
@@ -70,7 +70,7 @@ namespace XamlStyler.Core.Options
         [Description(
             "Defines ordering rule of element key.\r\nUse ',' to seperate more than one attribute.\r\nAttributes listed in earlier group takes precedence than later groups.\r\nAttributes listed earlier in same group takes precedence than the ones listed later."
             )]
-        [DefaultValue("Key, x:Key")]
+        [DefaultValue("Key, x:Key, Uid, x:Uid")]
         string AttributeOrderKey { get; set; }
 
         [Category("Attribute Ordering Rule Groups")]

--- a/XamlStyler.Service/Options/StylerOptions.cs
+++ b/XamlStyler.Service/Options/StylerOptions.cs
@@ -28,7 +28,7 @@ namespace XamlStyler.Core.Options
 
             AttributeOrderWpfNamespace = "xmlns, xmlns:x";
 
-            AttributeOrderKey = "Key, x:Key";
+            AttributeOrderKey = "Key, x:Key, Uid, x:Uid";
             AttributeOrderName = "Name, x:Name, Title";
 
             AttributeOrderAttachedLayout =
@@ -109,7 +109,7 @@ namespace XamlStyler.Core.Options
         [Description(
             "Defines ordering rule of element key.\r\nUse ',' to seperate more than one attribute.\r\nAttributes listed in earlier group takes precedence than later groups.\r\nAttributes listed earlier in same group takes precedence than the ones listed later."
             )]
-        [DefaultValue("Key, x:Key")]
+        [DefaultValue("Key, x:Key, Uid, x:Uid")]
         public string AttributeOrderKey { get; set; }
 
         [Category("Attribute Ordering Rule Groups")]

--- a/XamlStyler.UnitTests/UnitTests.cs
+++ b/XamlStyler.UnitTests/UnitTests.cs
@@ -52,7 +52,7 @@ namespace XamlStyler.UnitTests
                                     {
                                         AttributeOrderClass = "x:Class",
                                         AttributeOrderWpfNamespace = "xmlns, xmlns:x",
-                                        AttributeOrderKey = "Key, x:Key",
+                                        AttributeOrderKey = "Key, x:Key, Uid, x:Uid",
                                         AttributeOrderName = "Name, x:Name, Title",
                                         AttributeOrderAttachedLayout =
                                             "Grid.Column, Grid.ColumnSpan, Grid.Row, Grid.RowSpan, Canvas.Right, Canvas.Bottom, Canvas.Left, Canvas.Top",


### PR DESCRIPTION
As Uid / x:Uid has a very important role in Windows 8 / WP XAML apps for
localization, I feel it deserves to be added to the key group as a
leading attribute and not end up between the 'leftover properties'.
