### PR TITLE
Do NOT reformat comment when comment contains xml elements

### DIFF
--- a/TestCommentHandling.xaml
+++ b/TestCommentHandling.xaml
@@ -16,6 +16,24 @@
         second line
     -->
 
+    <!--  Do not reformat commented xml tags -->
+	<!--<DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />-->
+	    <!--
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />
+ -->
+
     <!--  END: Test for COMMENT hanlding  -->
 
 </Root>

--- a/TestCommentHandling_output_expected.xaml
+++ b/TestCommentHandling_output_expected.xaml
@@ -16,6 +16,24 @@
     second line
   -->
 
+  <!--  Do not reformat commented xml tags  -->
+  <!--<DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />-->
+  <!--
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />
+  -->
+
   <!--  END: Test for COMMENT hanlding  -->
 
 </Root>

--- a/XamlStyler.Service/Helpers/StringExtension.cs
+++ b/XamlStyler.Service/Helpers/StringExtension.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace XamlStyler.Core.Helpers
 {
@@ -19,6 +21,18 @@ namespace XamlStyler.Core.Helpers
             }
 
             return buffer.ToString();
+        }
+
+        public static IEnumerable<string> GetLines(this string source)
+        {
+            using (var reader = new StringReader(source))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    yield return line;
+                }
+            }
         }
     }
 }

--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -409,27 +409,41 @@ namespace XamlStyler.Core
         private void ProcessComment(XmlReader xmlReader, ref string output)
         {
             string currentIndentString = GetIndentString(xmlReader.Depth);
-            string content = xmlReader.Value.Trim();
+            string content = xmlReader.Value;
 
             if (!output.EndsWith("\n"))
             {
                 output += Environment.NewLine;
             }
 
-            if (content.Contains("\n"))
+            if (content.Contains("<") && content.Contains(">"))
+            {
+                output += currentIndentString + "<!--";
+                if (content.Contains("\n"))
+                {
+                    output += string.Join(Environment.NewLine, content.GetLines().Select(x=>x.TrimEnd(' ')));
+                    if (content.TrimEnd(' ').EndsWith("\n"))
+                    {
+                        output += currentIndentString;
+                    }
+                }
+                else
+                    output += content;
+
+                output += "-->";
+            }
+            else if (content.Contains("\n"))
             {
                 output += currentIndentString + "<!--";
 
                 string contentIndentString = GetIndentString(xmlReader.Depth + 1);
-                string[] lines = content.Split('\n');
-
-                output = lines.Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
+                output = content.Trim().GetLines().Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
 
                 output += Environment.NewLine + currentIndentString + "-->";
             }
             else
             {
-                output += currentIndentString + "<!--  " + content + "  -->";
+                output += currentIndentString + "<!--  " + content.Trim() + "  -->";
             }
         }
 


### PR DESCRIPTION
This is to handle when you place a comment around a section of XAML, that you later expect to incorporate again.
In that case it is counterproductive to reformat comment. Just leave it as is.

Also handle mixed line endings correctly (DOS versus Unix line endings)