### PR TITLE
Fixed XAML markup alignment when KeepFirstAttributeOnSameLine is false

### DIFF
--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -647,9 +647,18 @@ namespace XamlStyler.Core
                         // Attributes with markup extension, always put on new line
                         if (attrInfo.IsMarkupExtension && Options.FormatMarkupExtension)
                         {
-                            string baseIndetationString = GetIndentString(xmlReader.Depth - 1) +
-                                                          String.Empty.PadLeft(elementName.Length + 2, ' ');
-                            string pendingAppend = attrInfo.ToMultiLineString(baseIndetationString);
+                            string baseIndentationString;
+                            if (Options.KeepFirstAttributeOnSameLine)
+                            {
+                                baseIndentationString = GetIndentString(xmlReader.Depth - 1) +
+                                                        String.Empty.PadLeft(elementName.Length + 2, ' ');
+                            }
+                            else
+                            {
+                                baseIndentationString = GetIndentString(xmlReader.Depth);
+                            }
+
+                            string pendingAppend = attrInfo.ToMultiLineString(baseIndentationString);
 
                             if (currentLineBuffer.Length > 0)
                             {

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.expected
@@ -1,0 +1,38 @@
+﻿<Root>
+  <SingleLineContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}">
+    test here
+  </SingleLineContent>
+  <SingleLineNoContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}" />
+  <MultiLineContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}">
+    test here
+  </MultiLineContent>
+  <MultiLineNoContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}" />
+  <MultiLineProperContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}">
+    test here
+  </MultiLineProperContent>
+  <MultiLineProperNoContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}" />
+</Root>

--- a/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestMarkupWithAttributeNotOnFirstLine.testxaml
@@ -1,0 +1,24 @@
+﻿<Root>
+  <SingleLineContent a="a" b="{Binding Test, Converter={StaticResource VisibilityConverter}, ConverterParameter=Inverse}">test here</SingleLineContent>
+  <SingleLineNoContent a="a" b="{Binding Test, Converter={StaticResource VisibilityConverter}, ConverterParameter=Inverse}" />
+  <MultiLineContent
+    a="a"
+    b="{Binding Test, Converter={StaticResource VisibilityConverter}, ConverterParameter=Inverse}">
+    test here
+  </MultiLineContent>
+  <MultiLineNoContent
+    a="a"
+    b="{Binding Test, Converter={StaticResource VisibilityConverter}, ConverterParameter=Inverse}" />
+  <MultiLineProperContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter},
+                ConverterParameter=Inverse}">
+    test here
+  </MultiLineProperContent>
+  <MultiLineProperNoContent
+    a="a"
+    b="{Binding Test,
+                Converter={StaticResource VisibilityConverter}, 
+                ConverterParameter=Inverse}" />
+</Root>

--- a/XamlStyler.UnitTests/UnitTests.cs
+++ b/XamlStyler.UnitTests/UnitTests.cs
@@ -83,6 +83,18 @@ namespace XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestMarkupWithAttributeNotOnFirstLine()
+        {
+            var stylerOptions = new StylerOptions
+            {
+                KeepFirstAttributeOnSameLine = false,
+                AttributesTolerance = 1
+            };
+
+            DoTest(stylerOptions);
+        }
+
+        [Test]
         public void TestNoContentElementHandling()
         {
             DoTest();

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -117,6 +117,12 @@
     <None Include="TestFiles\TestMarkupExtensionHandling.testxaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestMarkupWithAttributeNotOnFirstLine.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestMarkupWithAttributeNotOnFirstLine.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\TestNestedCanvasChildrenHandling.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixed the issue where XAML markup properties got too much indentation when KeepFirstAttributeOnSameLine was false.

Added a unit test and made sure all existing unit tests pass.