### PR TITLE
Supporting last '#region' & '#endregion' tags in XAML.

### DIFF
--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -329,6 +329,14 @@ namespace XamlStyler.Core
 
                 output.Append("-->");
             }
+            else if (content.Contains("#region") || content.Contains("#endregion"))
+            {
+                output
+                    .Append(currentIndentString)
+                    .Append("<!--")
+                    .Append(content.Trim())
+                    .Append("-->");
+            }
             else if (content.Contains("\n"))
             {
                 output

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.expected
@@ -76,6 +76,7 @@
           <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
         </StackPanel>
       </StackPanel>
+      <!--#region This is a ViewPort-->
       <Viewport3D Name="mainViewport" ClipToBounds="True">
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100" FieldOfView="70" LookDirection="-11,-10,-9"
@@ -87,6 +88,7 @@
           </ModelVisual3D.Content>
         </ModelVisual3D>
       </Viewport3D>
+      <!--#endregion-->
     </DockPanel>
   </Grid>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestAttributeOrderRuleGroupsOnSeparateLinesHandling.testxaml
@@ -89,6 +89,7 @@
                     <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
                 </StackPanel>
             </StackPanel>
+            <!--#region This is a ViewPort-->
             <Viewport3D Name="mainViewport" ClipToBounds="True">
                 <Viewport3D.Camera>
                     <PerspectiveCamera FarPlaneDistance="100"
@@ -104,6 +105,7 @@
                     </ModelVisual3D.Content>
                 </ModelVisual3D>
             </Viewport3D>
+            <!--#endregion-->
         </DockPanel>
     </Grid>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.expected
@@ -70,6 +70,7 @@
           <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
         </StackPanel>
       </StackPanel>
+      <!--#region This is a ViewPort-->
       <Viewport3D Name="mainViewport" ClipToBounds="True">
         <Viewport3D.Camera>
           <PerspectiveCamera FarPlaneDistance="100"
@@ -85,6 +86,7 @@
           </ModelVisual3D.Content>
         </ModelVisual3D>
       </Viewport3D>
+      <!--#endregion-->
     </DockPanel>
   </Grid>
 </Window>

--- a/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestDefaultHandling.testxaml
@@ -70,6 +70,7 @@
                     <Button Name="cubeButton" Click="cubeButtonClick">Cube</Button>
                 </StackPanel>
             </StackPanel>
+            <!--#region This is a ViewPort-->
             <Viewport3D Name="mainViewport" ClipToBounds="True">
                 <Viewport3D.Camera>
                     <PerspectiveCamera FarPlaneDistance="100"
@@ -85,6 +86,7 @@
                     </ModelVisual3D.Content>
                 </ModelVisual3D>
             </Viewport3D>
+            <!--#endregion-->
         </DockPanel>
     </Grid>
 </Window>

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -36,8 +36,25 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.WithFramework.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.WithFramework.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.WithFramework.2.0.0\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.WithFramework.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.WithFramework.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/XamlStyler.UnitTests/packages.config
+++ b/XamlStyler.UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter.WithFramework" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Supporting last out-of-the-box Visual Studio 2015 '#region'  & '#endregion' tags in XAML.

With the unmodified implentation the tag #región & #endregion:
```xml
<!--#region This is a ViewPort-->'
```
Is modified in this way (with two spaces):
```xml
<!--  #region This is a ViewPort  -->'
```
After adding thouse spaces the tags are invalidated and not collapsed/expanded is available on regions.  They are treated as normal comments.

I have added a few tests to check it.