### PR TITLE
Bug fixes unnecessary blank line is generated when there is a comment…

### DIFF
--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -307,7 +307,7 @@ namespace XamlStyler.Core
             string currentIndentString = GetIndentString(xmlReader.Depth);
             string content = xmlReader.Value;
 
-            if (!output.IsNewLine())
+            if (output.Length > 0 && !output.IsNewLine())
             {
                 output.Append(Environment.NewLine);
             }

--- a/XamlStyler.UnitTests/TestFiles/TestCommentAtFirstLine.expected
+++ b/XamlStyler.UnitTests/TestFiles/TestCommentAtFirstLine.expected
@@ -1,0 +1,2 @@
+﻿<!--  comment at first line  -->
+<Root />

--- a/XamlStyler.UnitTests/TestFiles/TestCommentAtFirstLine.testxaml
+++ b/XamlStyler.UnitTests/TestFiles/TestCommentAtFirstLine.testxaml
@@ -1,0 +1,2 @@
+﻿<!--  comment at first line  -->
+<Root />

--- a/XamlStyler.UnitTests/UnitTests.cs
+++ b/XamlStyler.UnitTests/UnitTests.cs
@@ -42,6 +42,12 @@ namespace XamlStyler.UnitTests
         }
 
         [Test]
+        public void TestCommentAtFirstLine()
+        {
+            DoTest();
+        }
+
+        [Test]
         public void TestDefaultHandling()
         {
             DoTest();

--- a/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
+++ b/XamlStyler.UnitTests/XamlStyler.UnitTest.csproj
@@ -186,6 +186,12 @@
     <None Include="TestFiles\TestxBindSplitting.testxaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\TestCommentAtFirstLine.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\TestCommentAtFirstLine.testxaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
When first element of XAML is comment, unnecessary blank line is added at top of file.

Source:
```
<!-- comment -->
```

Result:
```

<!-- comment -->
```