### PR TITLE
"#10 Order attributes by name" options is always shown as changed

### DIFF
--- a/XamlStyler.Service/Options/IStylerOptions.cs
+++ b/XamlStyler.Service/Options/IStylerOptions.cs
@@ -23,7 +23,7 @@ namespace XamlStyler.Core.Options
         [Category("Attribute Ordering Rule Groups")]
         [DisplayName("#10 Order attributes by name")]
         [Description("Enable sorting of attributes by name")]
-        [DefaultValue("True")]
+        [DefaultValue(true)]
         bool OrderAttributesByName { get; set; }
 
         [Category("Attribute Ordering Rule Groups")]

--- a/XamlStyler.Service/Options/StylerOptions.cs
+++ b/XamlStyler.Service/Options/StylerOptions.cs
@@ -80,7 +80,7 @@ namespace XamlStyler.Core.Options
         [Category("Attribute Ordering Rule Groups")]
         [DisplayName("#10 Order attributes by name")]
         [Description("Enable sorting of attributes by name")]
-        [DefaultValue("True")]
+        [DefaultValue(true)]
         public bool OrderAttributesByName { get; set; }
 
         [Category("Attribute Ordering Rule Groups")]


### PR DESCRIPTION
The option "# 10 Order attributes by name" in Attribute Ordering Rule Groups is always shown as changed. The value of the option is always displayed in bold, regardless of whether true or false.
